### PR TITLE
fix the return value of __system_property_get

### DIFF
--- a/module/src/main/cpp/hook.cpp
+++ b/module/src/main/cpp/hook.cpp
@@ -24,6 +24,7 @@ NEW_FUNC_DEF(int, __system_property_get, const char *key, char *value) {
     if (prop) {
         LOGI("system_property_get: %s=%s -> %s", key, value, prop->value.c_str());
         strcpy(value, prop->value.c_str());
+        res = (int)prop->value.length();
     }
     return res;
 }


### PR DESCRIPTION
__system_property_get should return the length of value in the case of old___system_property_get returning 0